### PR TITLE
Fix exception when Instance.friends is List[str]

### DIFF
--- a/vrchat_api/jsonObject.py
+++ b/vrchat_api/jsonObject.py
@@ -63,7 +63,7 @@ class World(JsonObject):
 
 class Instance(JsonObject):
     def __init__(self, j):
-        setattr(self, "friends", [User(x) for x in j["friends"]] if j["friends"] != False else [])
+        setattr(self, "friends", [x if isinstance(x, str) else User(x) for x in j["friends"]] if j["friends"] != False else [])
         setattr(self, "users", [User(x) for x in j["users"]] if j["users"] != False else [])
         super().__init__(j)
 


### PR DESCRIPTION
VRChatAPI.findInstanceById sometimes fails due to instance.friends being a list of user ids.
Alternatively the id could be matched towards the users gotten in Instance.users.